### PR TITLE
Fixed format on save bug

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -11,6 +11,7 @@ module.exports = {
   parserOptions: {
     project: './tsconfig.json',
     sourceType: 'module',
+    tsconfigRootDir: __dirname,
   },
   settings: {
     'import/parsers': {


### PR DESCRIPTION
Corrected eslintrc.js so that format on save with eslint-prettier now works correctly in VSCode